### PR TITLE
fix multiple images with same tag

### DIFF
--- a/Plugin/ReplaceTags.php
+++ b/Plugin/ReplaceTags.php
@@ -69,13 +69,16 @@ class ReplaceTags
             return $output;
         }
 
-        if (preg_match_all('/<([^<]+)\ src=\"([^\"]+)\.(png|jpg|jpeg)([^>]+)>/mi', $output, $matches) === false) {
+        if (preg_match_all('/<([^<]+)\ src=\"([^\"]+)\.(png|jpg|jpeg)([^>]+)>/mi', $output, $matches, PREG_OFFSET_CAPTURE) === false) {
             return $output;
         }
-
+        
+		$accum_change = 0;
+		
         foreach ($matches[0] as $index => $match) {
-            $htmlTag = $matches[0][$index];
-            $imageUrl = $matches[2][$index] . '.' . $matches[3][$index];
+	        $offset = $match[1] + $accum_change;
+            $htmlTag = $matches[0][$index][0];
+            $imageUrl = $matches[2][$index][0] . '.' . $matches[3][$index][0];
 
             $webpUrl = $this->file->toWebp($imageUrl);
             $altText = $this->getAltText($htmlTag);
@@ -97,7 +100,8 @@ class ReplaceTags
                 ->setOriginalTag($htmlTag)
                 ->toHtml();
 
-            $output = str_replace($htmlTag, $newHtmlTag, $output);
+            $output = substr_replace($output, $newHtmlTag, $offset, strlen($htmlTag));
+            $accum_change = $accum_change + (strlen($newHtmlTag) - strlen($htmlTag));
         }
 
         return $output;


### PR DESCRIPTION
Currently, if you have multiple images on a page with the exact same tag (ie, 5 copies of the same image), the code will create nested comments, leaving trailing -->'s all over the code.  This is because of the use of str_replace in the ReplaceTags class, which replaces *all* copies of a tag, and will then replace the same tag multiple times.  

I updated to use substr_replace and PREG_OFFSET_CAPTURE to target the specific instance of the tag which is being replaced, and not all copies of the tag.