### PR TITLE
Skip captcha images

### DIFF
--- a/Plugin/ReplaceTags.php
+++ b/Plugin/ReplaceTags.php
@@ -101,6 +101,11 @@ class ReplaceTags
             $htmlTag = preg_replace('/>(.*)/msi', '>', $fullSearchMatch);
             $imageUrl = $matches[2][$index] . '.' . $matches[3][$index];
 
+            // Skip captcha images, otherwise refresh captcha won't work
+            if (strpos($imageUrl, '/media/captcha/') !== false) {
+                continue;
+            }
+
             $webpUrl = $this->file->toWebp($imageUrl);
 
             try {


### PR DESCRIPTION
The javascript file `vendor/magento/module-captcha/view/frontend/web/js/captcha.js` can't do it's job when the image tag is replaced with a picture tag. Skipping images with the URL `/media/captcha/` seems like the best approach to us.