### PR TITLE
Add jQuery Cookie to prevent load order issues

### DIFF
--- a/view/frontend/web/js/detect.js
+++ b/view/frontend/web/js/detect.js
@@ -7,7 +7,8 @@
  */
 
 define([
-    'jquery'
+    'jquery',
+    'jquery/jquery.cookie'
 ], function ($) {
 
     return function(config) {


### PR DESCRIPTION
This change resolves the following issue:

`detect.js:14 Uncaught TypeError: $.cookie is not a function`

This occured on M2.3.5-p2 on developer mode with the 'Move JS code to the bottom of the page' turned on.