### PR TITLE
Fixes wrong name in require-js config

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -5,7 +5,7 @@ var config = {
     config: {
         mixins: {
             'Magento_Swatches/js/swatch-renderer': {
-                'Yireo_Webp2/js/webp-swatch-renderer': true
+                'Yireo_Webp2/js/swatch-renderer': true
             },
         }
     }


### PR DESCRIPTION
The require-js-config file doesn't contain the correct filename.