### PR TITLE
Allow 2 img tags rendered next to each other to be converted to webp images

### DIFF
--- a/Image/HtmlReplacer.php
+++ b/Image/HtmlReplacer.php
@@ -67,13 +67,13 @@ class HtmlReplacer
      */
     public function replaceImagesInHtml(LayoutInterface $layout, string $html): string
     {
-        $regex = '/<([^<]+)\ src=\"([^\"]+)\.(png|jpg|jpeg)([^>]+)>(\s*)<(\/?)([a-z]+)/msi';
+        $regex = '/<([^<]+)\ src=\"([^\"]+)\.(png|jpg|jpeg)([^>]+)>(\s*)(<(\/[a-z]+))?/msi';
         if (preg_match_all($regex, $html, $matches) === false) {
             return $html;
         }
 
         foreach ($matches[0] as $index => $match) {
-            $nextTag = $matches[6][$index] . $matches[7][$index];
+            $nextTag = $matches[7][$index];
             $fullSearchMatch = $matches[0][$index];
             $imageUrl = $matches[2][$index] . '.' . $matches[3][$index];
 
@@ -92,7 +92,7 @@ class HtmlReplacer
 
             $htmlTag = preg_replace('/>(.*)/msi', '>', $fullSearchMatch);
             $newHtmlTag = $this->getNewHtmlTag($layout, $imageUrl, $webpUrl, $htmlTag);
-            $replacement = $newHtmlTag . '<' . $nextTag;
+            $replacement = $nextTag ? $newHtmlTag . '<' . $nextTag : $newHtmlTag;
             $html = str_replace($fullSearchMatch, $replacement, $html);
         }
 


### PR DESCRIPTION
Issue: 
The regex `/<([^<]+)\ src=\"([^\"]+)\.(png|jpg|jpeg)([^>]+)>(\s*)<(\/?)([a-z]+)/msi` can't detect 2 img tags rendered next to each other. Below is an example of the HTML that the layout rendered:
```
<img class="pagebuilder-mobile-hidden" src="desktop_image.jpg" data-element="desktop_image">
<img class="pagebuilder-mobile-only" src="mobile_image.jpg" data-element="mobile_image">
```

The current regex only matches the first img tag while it should match both of them. See [here](https://prnt.sc/uo51va)

Proposal solution: 
Update regex to identify 2 img tags rendered next to each other while also support the check if the image is placed within the picture tag. 
See the following screenshots for the demonstration of the fix:
https://prnt.sc/uo534x
https://prnt.sc/uo53xs
https://prnt.sc/uo56d6 https://prnt.sc/uo56ib


