### PR TITLE
Fix the 'Fallback to JQueryUI Compat activated' for Magento version 2.3.3 and above

### DIFF
--- a/view/frontend/web/js/swatch-renderer.js
+++ b/view/frontend/web/js/swatch-renderer.js
@@ -1,6 +1,5 @@
 define([
     'jquery',
-    'jquery/ui',
     "domReady!"
 ], function ($) {
     'use strict';


### PR DESCRIPTION
Issue:
- After installing the module on a Magento version 2.3.3 (or above), the following warning stated on the console:

> Fallback to JQueryUI Compat activated. Your store is missing a dependency for a jQueryUI widget. Identifying and addressing the dependency will drastically improve the performance of your site.

The reason the issue occurs is that we inject the 'jquery/ui' as a dependency to our mixin and from Magento 2.3.3, jquery UI is restructured and causes the issue.

Proposal solution:
- Remove 'jquery/ui' as a dependency on mixin Yireo_Webp2/js/swatch-renderer as we don't need to inject 'jquery/ui' when creating a mixin.

Reference doc: 
https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/javascript/js_mixins.html

