### PR TITLE
Add support `data-src` attributes on image tags

### DIFF
--- a/Block/Picture.php
+++ b/Block/Picture.php
@@ -56,6 +56,11 @@ class Picture extends Template
      * @var bool
      */
     private $lazyLoading = true;
+    
+    /**
+     * @var bool
+     */
+    private $isDataSrc = false;
 
     /**
      * @return string
@@ -236,6 +241,25 @@ class Picture extends Template
     public function setLazyLoading(bool $lazyLoading)
     {
         $this->lazyLoading = $lazyLoading;
+
+        return $this;
+    }
+    
+    /**
+     * @return bool
+     */
+    public function getIsDataSrc(): bool
+    {
+        return $this->dataSrc;
+    }
+
+    /**
+     * @param bool $dataSrc
+     * @return $this
+     */
+    public function setIsDataSrc(bool $dataSrc)
+    {
+        $this->dataSrc = $dataSrc;
 
         return $this;
     }

--- a/Image/HtmlReplacer.php
+++ b/Image/HtmlReplacer.php
@@ -67,15 +67,15 @@ class HtmlReplacer
      */
     public function replaceImagesInHtml(LayoutInterface $layout, string $html): string
     {
-        $regex = '/<([^<]+)\ src=\"([^\"]+)\.(png|jpg|jpeg)([^>]+)>(\s*)(<(\/[a-z]+))?/msi';
+        $regex = '/<([^<]+)\ (data\-src|src)=\"([^\"]+)\.(png|jpg|jpeg)([^>]+)>(\s*)(<(\/[a-z]+))?/msi';
         if (preg_match_all($regex, $html, $matches) === false) {
             return $html;
         }
 
         foreach ($matches[0] as $index => $match) {
-            $nextTag = $matches[7][$index];
+            $nextTag = $matches[8][$index];
             $fullSearchMatch = $matches[0][$index];
-            $imageUrl = $matches[2][$index] . '.' . $matches[3][$index];
+            $imageUrl = $matches[3][$index] . '.' . $matches[4][$index];
 
             if (!$this->isAllowedByNextTag($nextTag)) {
                 continue;
@@ -91,7 +91,7 @@ class HtmlReplacer
             }
 
             $htmlTag = preg_replace('/>(.*)/msi', '>', $fullSearchMatch);
-            $newHtmlTag = $this->getNewHtmlTag($layout, $imageUrl, $webpUrl, $htmlTag);
+            $newHtmlTag = $this->getNewHtmlTag($layout, $imageUrl, $webpUrl, $htmlTag, $matches[2][$index] === 'data-src');
             $replacement = $nextTag ? $newHtmlTag . '<' . $nextTag : $newHtmlTag;
             $html = str_replace($fullSearchMatch, $replacement, $html);
         }
@@ -132,7 +132,7 @@ class HtmlReplacer
      * @param $htmlTag
      * @return string
      */
-    private function getNewHtmlTag(LayoutInterface $layout, string $imageUrl, string $webpUrl, $htmlTag): string
+    private function getNewHtmlTag(LayoutInterface $layout, string $imageUrl, string $webpUrl, $htmlTag, bool $isDataSrc = false): string
     {
         return (string)$this->getPictureBlock($layout)
             ->setOriginalImage($imageUrl)
@@ -142,6 +142,7 @@ class HtmlReplacer
             ->setClass($this->getAttributeText($htmlTag, 'class'))
             ->setWidth($this->getAttributeText($htmlTag, 'width'))
             ->setHeight($this->getAttributeText($htmlTag, 'height'))
+            ->setIsDataSrc($isDataSrc)
             ->toHtml();
     }
 

--- a/view/frontend/templates/picture.phtml
+++ b/view/frontend/templates/picture.phtml
@@ -18,7 +18,7 @@ $originalImageType = $block->getOriginalImageType();
     <!-- <?= /* @noEscape */ $block->getOriginalTag() ?> -->
 <?php endif; ?>
 <picture<?= /* @noEscape */ $class ?>>
-    <source type="image/webp" srcset="<?= /* @noEscape */ $block->getWebpImage() ?>">
-    <source type="<?= /* @noEscape */ $originalImageType ?>" srcset="<?= /* @noEscape */ $originalImage ?>">
+    <source type="image/webp" <?php if($block->getIsDataSrc()): ?>data-srcset="<?= /* @noEscape */ $block->getWebpImage() ?>"<?php else: ?>srcset="<?= /* @noEscape */ $block->getWebpImage() ?>"<?php endif; ?>>
+    <source type="<?= /* @noEscape */ $originalImageType ?>" <?php if($block->getIsDataSrc()): ?>data-srcset="<?= /* @noEscape */ $block->getWebpImage() ?>"<?php else: ?>srcset="<?= /* @noEscape */ $originalImage ?>"<?php endif; ?>>
     <?= /* @noEscape */ $originalTag ?>
 </picture>


### PR DESCRIPTION
Hi,

this PR provides support `data-src` Attributes on image Tags. Currently the extension can only convert image tags with a an `src` Tags, but in our integrations we are using a common lazy load approach to load defer off screen images. 

If you have questions feel free, to contact me.

Thanks!

Greetings
\- Thomas