### PR TITLE
When no .webp file is available, the source tag will be removed to prevent old image being shown on the frontend

### DIFF
--- a/view/frontend/web/js/swatch-renderer.js
+++ b/view/frontend/web/js/swatch-renderer.js
@@ -11,6 +11,8 @@ define([
              *
              * Overwritten to make sure the image in the category grid is updated
              * when clicking a swatch image.
+             * When no .webp file is available the source tag will be removed
+             * to prevent old image being shown on the frontend.
              *
              * @param {Array} images
              * @param {jQuery} context
@@ -23,13 +25,23 @@ define([
                     const justAnImage = images[0];
 
                     if (justAnImage && justAnImage.img) {
-                        justAnImage.img.indexOf('.webp') !== -1
-                            ? context
-                                .find('[type="image/webp"]')
-                                .attr('srcset', justAnImage.img)
-                            : context
+                        const webpSourceTag = context.find('[type="image/webp"]');
+
+                        if (justAnImage.img.indexOf('.webp') !== -1) {
+                            (webpSourceTag !== undefined)
+                                ? webpSourceTag.attr('srcset', justAnImage.img)
+                                : context
+                                    .find('.product-image-photo')
+                                    .prepend('<source type="image/webp" srcset="' + justAnImage.img + '">');
+                        } else {
+                            if (webpSourceTag !== undefined) {
+                                webpSourceTag.remove();
+                            }
+
+                            context
                                 .find('[type="image/jpg"], [type="image/png"]')
                                 .attr('srcset', justAnImage.img);
+                        }
 
                     }
                 }


### PR DESCRIPTION
Hi @jissereitsma 

This bug came back from a client. The webp source was not renewed in some cases for a configurable product on the listing page. As result the old webp image was still shown. I've fixed this in their theme now, but it would be cool to have it also in the module  