### PR TITLE
Fallback to non-webp url in case of a ConvertorException on product page

### DIFF
--- a/Plugin/AddWebpToConfigurableJsonConfig.php
+++ b/Plugin/AddWebpToConfigurableJsonConfig.php
@@ -74,10 +74,13 @@ class AddWebpToConfigurableJsonConfig
     /**
      * @param string $url
      * @return string
-     * @throws ConvertorException
      */
     private function getWebpUrl(string $url): string
     {
-        return $this->convertor->getSourceImage($url)->getUrl();
+        try {
+            return $this->convertor->getSourceImage($url)->getUrl();
+        } catch (ConvertorException $ex) {
+            return $url;
+        }
     }
 }

--- a/Plugin/AddWebpToGalleryImagesJson.php
+++ b/Plugin/AddWebpToGalleryImagesJson.php
@@ -66,10 +66,13 @@ class AddWebpToGalleryImagesJson
     /**
      * @param string $url
      * @return string
-     * @throws ConvertorException
      */
     private function getWebpUrl(string $url): string
     {
-        return $this->convertor->getSourceImage($url)->getUrl();
+        try {
+            return $this->convertor->getSourceImage($url)->getUrl();
+        } catch(ConvertorException $ex) {
+            return $url;
+        }
     }
 }


### PR DESCRIPTION
Hi @jissereitsma ,

First of all, thank you for your work on yet another great open-source extension.

After updating to the latest version I was getting an exception on product pages, saying `WebP URL "[...]" does not exist`. That seems to happen when an image does not need conversion (the `needsConversion` check on line 109 of the `Convertor` class returns `false`).
I didn't go too much in-depth on the extension behaviour on the frontend but I assumed, in that case, it was fine just to return the original image URL on the `getWebpUrl` method of the plugin. The alternative might have been to skip the part where the webp URLs are added to the image configuration on `appendImages`, but this way the code is potentially cleaner as there is only one try/catch and we still get the webp URL in case only one or two images do not need conversion.

Hope this helps!

Thanks again,
Renato