### PR TITLE
Fix error to config.xml introduced in last version

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -15,7 +15,7 @@
                 <enabled>1</enabled>
                 <quality_level>80</quality_level>
                 <convertors>cwebp,gd,imagick,wpc,ewww</convertors>
-                <convertors>lossy</convertors>
+                <encoding>lossy</encoding>
             </settings>
         </yireo_webp2>
     </default>


### PR DESCRIPTION
lossy default was set with the wrong group name.