### PR TITLE
Remove async from function (IE11 Support)

### DIFF
--- a/view/frontend/web/js/has-webp.js
+++ b/view/frontend/web/js/has-webp.js
@@ -1,7 +1,7 @@
 define([], function () {
     'use strict';
 
-    return async function hasWebP() {
+    return function hasWebP() {
         var elem = document.createElement('canvas');
 
         if (!!(elem.getContext && elem.getContext('2d'))) {


### PR DESCRIPTION
Now that the `await` has been removed (https://github.com/yireo/Yireo_Webp2/commit/6360fe3f668018f8201dc318785471b1a7cc3147), I don't think the `async` is required here?
Removing the `async` allows for IE11 support, which is mostly the case where WebP isn't supported.