### PR TITLE
Added ACL for user permissions

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Yireo_Webp2::config" title="Yireo_Webp2" sortOrder="100"/>
+            </resource>
+        </resources>
+    </acl>
+</config>


### PR DESCRIPTION
I saw that there is a <resource> used in the system.xml but there is no acl.xml. This makes the module invisible in the admin when using custom roles resources for users.