### PR TITLE
Uncaught Exception

### DIFF
--- a/Convertor/Convertor.php
+++ b/Convertor/Convertor.php
@@ -15,6 +15,7 @@ use Yireo\NextGenImages\Image\ImageFactory;
 use Yireo\Webp2\Config\Config;
 use Yireo\Webp2\Exception\InvalidConvertorException;
 use WebPConvert\Exceptions\InvalidInput\InvalidImageTypeException as InvalidInputImageTypeException;
+use WebPConvert\Exceptions\InvalidInputException;
 
 class Convertor implements ConvertorInterface
 {
@@ -102,7 +103,7 @@ class Convertor implements ConvertorInterface
 
         try {
             $this->convertWrapper->convert($sourceImagePath, $targetImagePath);
-        } catch (InvalidImageTypeException | InvalidInputImageTypeException $e) {
+        } catch (InvalidImageTypeException | InvalidInputException | InvalidInputImageTypeException $e) {
             return false;
         } catch (ConversionFailedException | InvalidConvertorException $e) {
             throw new ConvertorException($targetImagePath . ': ' . $e->getMessage());


### PR DESCRIPTION
Hi @jissereitsma!

We came across an issue on one of our sites where there was an uncaught exception that was causing the site to unexpectedly crash. In the package `rosell-dk/webp-convert`, the `WebPConvert\Exceptions\InvalidInputException` is thrown under multiple conditions but these are not checked for in this module. I created a patch for our site that checked for this exception and it fixed the issue. I thought I would open a PR with this change to hopefully prevent others from facing this issue.