### PR TITLE
Catch the correct exception when using properties of a specific exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.4] - 26 September 2023
+### Fixed
+- Catch the correct exception when using properties of a specific exception.
+
 ## [0.13.3] - 22 September 2023
 ### Fixed
 - Properly check for MIME-typed (fix of #149)

--- a/Convertor/ConvertWrapper.php
+++ b/Convertor/ConvertWrapper.php
@@ -48,15 +48,18 @@ class ConvertWrapper
     public function convert(string $sourceImageFilename, string $destinationImageFilename): void
     {
         $options = $this->getOptions();
-        foreach ($this->config->getConvertors() as $convertor) {
+        foreach ($this->config->getConvertors() as $convertor){
             $options['converter'] = $convertor;
             try {
                 WebPConvert::convert($sourceImageFilename, $destinationImageFilename, $options);
-                break;
-            } catch (Exception $e) {
+            } catch (ConversionFailedException $e) {
+                $this->logger->debug($e->getMessage() . ' - ' . $e->description, $e->getTrace());
+                continue;
+            } catch (\Exception $e) {
                 $this->logger->debug($e->getMessage(), $e->getTrace());
                 continue;
             }
+            break;
         }
     }
 


### PR DESCRIPTION
This error is thrown occasionaly when the converter runs into an Exception.
The original code catches the generic \Exception but the message generated there expects a description property that is only present in the ConversionFailedException.


```
[2023-09-26 report.CRITICAL: Exception: Warning: Undefined property: Exception::$description in ../vendor/yireo/magento2-webp2/Convertor/ConvertWrapper.php on line 55 in ..//vendor/magento/framework/App/ErrorHandler.php:62
Stack trace:

```